### PR TITLE
feat!: Drop readable-stream & use bl directly

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,24 +18,26 @@ Utility to read the contents of a vinyl file.
   It is only meant for demonstation purposes.
   For a more complete implementation, see: https://github.com/gulp-community/gulp-pug
 */
-var through = require('through2');
+var { Transform } = require('streamx');
 var pug = require('pug');
 var vinylContents = require('vinyl-contents');
 
 function gulpPug(options) {
-  return through.obj(function (file, _enc, cb) {
-    vinylContents(file, function (err, contents) {
-      if (err) {
-        return cb(err);
-      }
+  return new Transform({
+    transform: function (file, cb) {
+      vinylContents(file, function (err, contents) {
+        if (err) {
+          return cb(err);
+        }
 
-      if (!contents) {
-        return cb();
-      }
+        if (!contents) {
+          return cb();
+        }
 
-      file.contents = pug.compile(contents.toString(), options)();
-      cb(null, file);
-    });
+        file.contents = pug.compile(contents.toString(), options)();
+        cb(null, file);
+      });
+    },
   });
 }
 ```

--- a/index.js
+++ b/index.js
@@ -1,6 +1,5 @@
 'use strict';
 
-var stream = require('readable-stream');
 var Vinyl = require('vinyl');
 var bl = require('bl');
 
@@ -16,15 +15,15 @@ function vinylContents(file, cb) {
   }
 
   if (file.isStream()) {
-    var bufferList = bl();
-    stream.pipeline([file.contents, bufferList], function (err) {
+    var bufferList = bl(function (err, data) {
       if (err) {
         cb(err);
         return;
       }
 
-      cb(null, bufferList);
+      cb(null, data);
     });
+    file.contents.pipe(bufferList);
     return;
   }
 

--- a/package.json
+++ b/package.json
@@ -22,8 +22,7 @@
     "test": "nyc mocha --async-only"
   },
   "dependencies": {
-    "bl": "^3.0.0",
-    "readable-stream": "^3.3.0",
+    "bl": "^5.0.0",
     "vinyl": "^2.2.0"
   },
   "devDependencies": {
@@ -33,7 +32,9 @@
     "expect": "^27.0.0",
     "from2": "^2.3.0",
     "mocha": "^8.0.0",
-    "nyc": "^15.0.0"
+    "nyc": "^15.0.0",
+    "readable-stream": "^3.6.0",
+    "streamx": "^2.12.5"
   },
   "nyc": {
     "reporter": [

--- a/package.json
+++ b/package.json
@@ -30,7 +30,6 @@
     "eslint-config-gulp": "^5.0.0",
     "eslint-plugin-node": "^11.1.0",
     "expect": "^27.0.0",
-    "from2": "^2.3.0",
     "mocha": "^8.0.0",
     "nyc": "^15.0.0",
     "readable-stream": "^3.6.0",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   },
   "dependencies": {
     "bl": "^5.0.0",
-    "vinyl": "^2.2.0"
+    "vinyl": "^3.0.0"
   },
   "devDependencies": {
     "eslint": "^7.0.0",

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -2,100 +2,156 @@
 
 var expect = require('expect');
 var Vinyl = require('vinyl');
-var from = require('from2');
 
 var vinylContents = require('../');
 
-function makeEmptyFile() {
-  return new Vinyl({
-    path: 'test.js',
-    contents: null,
+function suite(moduleName) {
+  var stream = require(moduleName);
+
+  function makeEmptyFile() {
+    return new Vinyl({
+      path: 'test.js',
+      contents: null,
+    });
+  }
+
+  function makeBufferFile() {
+    return new Vinyl({
+      path: 'test.js',
+      contents: Buffer.from('var a = 1;'),
+    });
+  }
+
+  function makeStreamFile() {
+    return new Vinyl({
+      path: 'test.js',
+      contents: stream.Readable.from([
+        Buffer.from('var a'),
+        Buffer.from(' = '),
+        Buffer.from('1;'),
+      ]),
+    });
+  }
+
+  function makeImmediateErrorStreamFile() {
+    var contents = new stream.Readable({
+      read: function (cb) {
+        var err = new Error('boom!');
+        if (typeof cb === 'function') {
+          return cb(err);
+        }
+
+        this.destroy(err);
+      },
+    });
+
+    return new Vinyl({
+      path: 'test.js',
+      contents: contents,
+    });
+  }
+
+  function makeErrorStreamFile() {
+    var items = [Buffer.from('var a'), Buffer.from(' = '), Buffer.from('1;')];
+    var contents = new stream.Readable({
+      read: function (cb) {
+        var chunk = items.shift();
+        if (chunk) {
+          this.push(chunk);
+          if (typeof cb === 'function') {
+            cb();
+          }
+          return;
+        }
+
+        var err = new Error('boom!');
+        if (typeof cb === 'function') {
+          return cb(err);
+        }
+
+        this.destroy(err);
+      },
+    });
+
+    return new Vinyl({
+      path: 'test.js',
+      contents: contents,
+    });
+  }
+
+  var expectedBuffer = Buffer.from('var a = 1;');
+
+  describe('vinyl-contents (' + moduleName + ')', function () {
+    it('errors if not given a vinyl object', function (done) {
+      vinylContents({}, function (err, contents) {
+        expect(err).toBeInstanceOf(Error);
+        expect(contents).toBeUndefined();
+        done();
+      });
+    });
+
+    it('returns the contents of a Vinyl file with Buffer contents', function (done) {
+      var file = makeBufferFile();
+
+      vinylContents(file, function (err, contents) {
+        expect(err).toBeFalsy();
+        expect(contents).toEqual(expectedBuffer);
+        done();
+      });
+    });
+
+    it('returns the contents of a Vinyl file with Streaming contents', function (done) {
+      var file = makeStreamFile();
+
+      vinylContents(file, function (err, contents) {
+        expect(err).toBeFalsy();
+        expect(contents.toString()).toEqual(expectedBuffer.toString());
+        done();
+      });
+    });
+
+    it('works with String(contents)', function (done) {
+      var file = makeStreamFile();
+
+      vinylContents(file, function (err, contents) {
+        expect(err).toBeFalsy();
+        expect(String(contents)).toEqual(expectedBuffer.toString());
+        done();
+      });
+    });
+
+    it('returns empty contents if Vinyl file has no contents', function (done) {
+      var file = makeEmptyFile();
+
+      vinylContents(file, function (err, contents) {
+        expect(err).toBeFalsy();
+        expect(contents).toBeUndefined();
+        done();
+      });
+    });
+
+    it('surfaces immediate errors within content stream', function (done) {
+      var file = makeImmediateErrorStreamFile();
+
+      vinylContents(file, function (err, contents) {
+        expect(err).toBeInstanceOf(Error);
+        expect(contents).toBeUndefined();
+        done();
+      });
+    });
+
+    it('surfaces errors anywhere within content stream', function (done) {
+      var file = makeErrorStreamFile();
+
+      vinylContents(file, function (err, contents) {
+        expect(err).toBeInstanceOf(Error);
+        expect(contents).toBeUndefined();
+        done();
+      });
+    });
   });
 }
 
-function makeBufferFile() {
-  return new Vinyl({
-    path: 'test.js',
-    contents: Buffer.from('var a = 1;'),
-  });
-}
-
-function makeStreamFile() {
-  return new Vinyl({
-    path: 'test.js',
-    contents: from([
-      Buffer.from('var a'),
-      Buffer.from(' = '),
-      Buffer.from('1;'),
-    ]),
-  });
-}
-
-function makeErrorStreamFile() {
-  return new Vinyl({
-    path: 'test.js',
-    contents: from([new Error('boom!')]),
-  });
-}
-
-var expectedBuffer = Buffer.from('var a = 1;');
-
-describe('vinyl-contents', function () {
-  it('errors if not given a vinyl object', function (done) {
-    vinylContents({}, function (err, contents) {
-      expect(err).toBeInstanceOf(Error);
-      expect(contents).toBeUndefined();
-      done();
-    });
-  });
-
-  it('returns the contents of a Vinyl file with Buffer contents', function (done) {
-    var file = makeBufferFile();
-
-    vinylContents(file, function (err, contents) {
-      expect(err).toBeFalsy();
-      expect(contents).toEqual(expectedBuffer);
-      done();
-    });
-  });
-
-  it('returns the contents of a Vinyl file with Streaming contents', function (done) {
-    var file = makeStreamFile();
-
-    vinylContents(file, function (err, contents) {
-      expect(err).toBeFalsy();
-      expect(contents.toString()).toEqual(expectedBuffer.toString());
-      done();
-    });
-  });
-
-  it('works with String(contents)', function (done) {
-    var file = makeStreamFile();
-
-    vinylContents(file, function (err, contents) {
-      expect(err).toBeFalsy();
-      expect(String(contents)).toEqual(expectedBuffer.toString());
-      done();
-    });
-  });
-
-  it('returns empty contents if Vinyl file has no contents', function (done) {
-    var file = makeEmptyFile();
-
-    vinylContents(file, function (err, contents) {
-      expect(err).toBeFalsy();
-      expect(contents).toBeUndefined();
-      done();
-    });
-  });
-
-  it('surfaces errors within content stream', function (done) {
-    var file = makeErrorStreamFile();
-
-    vinylContents(file, function (err, contents) {
-      expect(err).toBeInstanceOf(Error);
-      expect(contents).toBeUndefined();
-      done();
-    });
-  });
-});
+suite('stream');
+suite('streamx');
+suite('readable-stream');

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -5,153 +5,167 @@ var Vinyl = require('vinyl');
 
 var vinylContents = require('../');
 
-function suite(moduleName) {
-  var stream = require(moduleName);
-
-  function makeEmptyFile() {
-    return new Vinyl({
-      path: 'test.js',
-      contents: null,
-    });
-  }
-
-  function makeBufferFile() {
-    return new Vinyl({
-      path: 'test.js',
-      contents: Buffer.from('var a = 1;'),
-    });
-  }
-
-  function makeStreamFile() {
-    return new Vinyl({
-      path: 'test.js',
-      contents: stream.Readable.from([
-        Buffer.from('var a'),
-        Buffer.from(' = '),
-        Buffer.from('1;'),
-      ]),
-    });
-  }
-
-  function makeImmediateErrorStreamFile() {
-    var contents = new stream.Readable({
-      read: function (cb) {
-        var err = new Error('boom!');
-        if (typeof cb === 'function') {
-          return cb(err);
-        }
-
-        this.destroy(err);
-      },
-    });
-
-    return new Vinyl({
-      path: 'test.js',
-      contents: contents,
-    });
-  }
-
-  function makeErrorStreamFile() {
-    var items = [Buffer.from('var a'), Buffer.from(' = '), Buffer.from('1;')];
-    var contents = new stream.Readable({
-      read: function (cb) {
-        var chunk = items.shift();
-        if (chunk) {
-          this.push(chunk);
-          if (typeof cb === 'function') {
-            cb();
-          }
-          return;
-        }
-
-        var err = new Error('boom!');
-        if (typeof cb === 'function') {
-          return cb(err);
-        }
-
-        this.destroy(err);
-      },
-    });
-
-    return new Vinyl({
-      path: 'test.js',
-      contents: contents,
-    });
-  }
-
-  var expectedBuffer = Buffer.from('var a = 1;');
-
-  describe('vinyl-contents (' + moduleName + ')', function () {
-    it('errors if not given a vinyl object', function (done) {
-      vinylContents({}, function (err, contents) {
-        expect(err).toBeInstanceOf(Error);
-        expect(contents).toBeUndefined();
-        done();
-      });
-    });
-
-    it('returns the contents of a Vinyl file with Buffer contents', function (done) {
-      var file = makeBufferFile();
-
-      vinylContents(file, function (err, contents) {
-        expect(err).toBeFalsy();
-        expect(contents).toEqual(expectedBuffer);
-        done();
-      });
-    });
-
-    it('returns the contents of a Vinyl file with Streaming contents', function (done) {
-      var file = makeStreamFile();
-
-      vinylContents(file, function (err, contents) {
-        expect(err).toBeFalsy();
-        expect(contents.toString()).toEqual(expectedBuffer.toString());
-        done();
-      });
-    });
-
-    it('works with String(contents)', function (done) {
-      var file = makeStreamFile();
-
-      vinylContents(file, function (err, contents) {
-        expect(err).toBeFalsy();
-        expect(String(contents)).toEqual(expectedBuffer.toString());
-        done();
-      });
-    });
-
-    it('returns empty contents if Vinyl file has no contents', function (done) {
-      var file = makeEmptyFile();
-
-      vinylContents(file, function (err, contents) {
-        expect(err).toBeFalsy();
-        expect(contents).toBeUndefined();
-        done();
-      });
-    });
-
-    it('surfaces immediate errors within content stream', function (done) {
-      var file = makeImmediateErrorStreamFile();
-
-      vinylContents(file, function (err, contents) {
-        expect(err).toBeInstanceOf(Error);
-        expect(contents).toBeUndefined();
-        done();
-      });
-    });
-
-    it('surfaces errors anywhere within content stream', function (done) {
-      var file = makeErrorStreamFile();
-
-      vinylContents(file, function (err, contents) {
-        expect(err).toBeInstanceOf(Error);
-        expect(contents).toBeUndefined();
-        done();
-      });
-    });
+function makeEmptyFile() {
+  return new Vinyl({
+    path: 'test.js',
+    contents: null,
   });
 }
 
-suite('stream');
-suite('streamx');
-suite('readable-stream');
+function makeBufferFile() {
+  return new Vinyl({
+    path: 'test.js',
+    contents: Buffer.from('var a = 1;'),
+  });
+}
+
+var expectedBuffer = Buffer.from('var a = 1;');
+
+describe('vinyl-contents', function () {
+  it('errors if not given a vinyl object', function (done) {
+    vinylContents({}, function (err, contents) {
+      expect(err).toBeInstanceOf(Error);
+      expect(contents).toBeUndefined();
+      done();
+    });
+  });
+
+  it('returns the contents of a Vinyl file with Buffer contents', function (done) {
+    var file = makeBufferFile();
+
+    vinylContents(file, function (err, contents) {
+      expect(err).toBeFalsy();
+      expect(contents).toEqual(expectedBuffer);
+      done();
+    });
+  });
+
+  it('returns empty contents if Vinyl file has no contents', function (done) {
+    var file = makeEmptyFile();
+
+    vinylContents(file, function (err, contents) {
+      expect(err).toBeFalsy();
+      expect(contents).toBeUndefined();
+      done();
+    });
+  });
+
+  function streamSuite(moduleName) {
+    var stream = require(moduleName);
+
+    function makeStreamFile() {
+      return new Vinyl({
+        path: 'test.js',
+        contents: stream.Readable.from([
+          Buffer.from('var a'),
+          Buffer.from(' = '),
+          Buffer.from('1;'),
+        ]),
+      });
+    }
+
+    function makeImmediateErrorStreamFile() {
+      var contents = new stream.Readable({
+        read: function (cb) {
+          var err = new Error('boom!');
+          if (typeof cb === 'function') {
+            return cb(err);
+          }
+
+          this.destroy(err);
+        },
+      });
+
+      return new Vinyl({
+        path: 'test.js',
+        contents: contents,
+      });
+    }
+
+    function makeErrorStreamFile() {
+      var items = [Buffer.from('var a'), Buffer.from(' = '), Buffer.from('1;')];
+      var contents = new stream.Readable({
+        read: function (cb) {
+          var chunk = items.shift();
+          if (chunk) {
+            this.push(chunk);
+            if (typeof cb === 'function') {
+              cb();
+            }
+            return;
+          }
+
+          var err = new Error('boom!');
+          if (typeof cb === 'function') {
+            return cb(err);
+          }
+
+          this.destroy(err);
+        },
+      });
+
+      return new Vinyl({
+        path: 'test.js',
+        contents: contents,
+      });
+    }
+
+    describe('with (' + moduleName + ')', function () {
+      it('returns the contents of a Vinyl file with Streaming contents', function (done) {
+        var file = makeStreamFile();
+
+        vinylContents(file, function (err, contents) {
+          expect(err).toBeFalsy();
+          expect(contents.toString()).toEqual(expectedBuffer.toString());
+          done();
+        });
+      });
+
+      it('works with String(contents)', function (done) {
+        var file = makeStreamFile();
+
+        vinylContents(file, function (err, contents) {
+          expect(err).toBeFalsy();
+          expect(String(contents)).toEqual(expectedBuffer.toString());
+          done();
+        });
+      });
+
+      it('surfaces immediate errors within content stream', function (done) {
+        var file = makeImmediateErrorStreamFile();
+
+        vinylContents(file, function (err, contents) {
+          expect(err).toBeInstanceOf(Error);
+          expect(contents).toBeUndefined();
+          done();
+        });
+      });
+
+      it('surfaces errors anywhere within content stream', function (done) {
+        var file = makeErrorStreamFile();
+
+        vinylContents(file, function (err, contents) {
+          expect(err).toBeInstanceOf(Error);
+          expect(contents).toBeUndefined();
+          done();
+        });
+      });
+
+      it('works with a cloned file that has streaming contents', function (done) {
+        var file = makeStreamFile();
+
+        var file2 = file.clone();
+
+        vinylContents(file2, function (err, contents) {
+          expect(err).toBeFalsy();
+          expect(contents.toString()).toEqual(expectedBuffer.toString());
+          done();
+        });
+      });
+    });
+  }
+
+  streamSuite('stream');
+  streamSuite('streamx');
+  streamSuite('readable-stream');
+});


### PR DESCRIPTION
This drops the use of `stream.pipeline` and uses the callback to `bl` directly. It also adds tests for streamx and node core streams.

Closes #6 

It is still a draft because it needs to update Vinyl to v3 once available.